### PR TITLE
Add ffplay option to prevent a server interrupting connection

### DIFF
--- a/pSub.py
+++ b/pSub.py
@@ -404,6 +404,7 @@ class pSub(object):
             '500',
             '-loglevel',
             'fatal',
+            '-infbuf',
         ]
 
         if not self.display:


### PR DESCRIPTION
Some servers (supysonic) interrupts long lasting connections ( it uses gunicorn+apache). Adding `-infbuf` option workarounds this.